### PR TITLE
Add the necessary 'global' option to binary:replace.

### DIFF
--- a/src/csv_gen.erl
+++ b/src/csv_gen.erl
@@ -15,7 +15,7 @@ field(File, Value) when is_binary(Value) ->
       file:write(File, Value);
     _ ->
       file:write(File, "\""),
-      file:write(File, binary:replace(Value, <<"\"">>, <<"\"\"">>)),
+      file:write(File, binary:replace(Value, <<"\"">>, <<"\"\"">>, [global])),
       file:write(File, "\"")
   end;
 field(File, Value) when is_list(Value) ->

--- a/test/csv_gen_tests.erl
+++ b/test/csv_gen_tests.erl
@@ -10,3 +10,14 @@ write_csv_test() ->
   {ok, Contents} = file:read_file("temp.csv"),
   io:format("wrote ~p~n",[Contents]),
   ?assertEqual(<<"Header 1,Header 2\n1,hello,good bye,\"with \"\" quote\",\"with \n newline\",\"with , comma\",2.000000,and the atom,hydrogen\n">>, Contents).
+
+double_quote_test() ->
+  {ok, File} = file:open("temp.csv", [write]),
+  csv_gen:row(File, ["Column 1", "Column 2", "Column 3", "Column 4"]),
+  csv_gen:row(File, ["two double-quote \"\"", <<"three double-quote \"\"\"">>, "four double-quote:\n \"\"\"\""]),
+  file:close(File),
+
+  {ok, Contents} = file:read_file("temp.csv"),
+  io:format("wrote ~s~n", [Contents]),
+  ?assertEqual(<<"Column 1,Column 2,Column 3,Column 4\n\"two double-quote \"\"\"\"\",\"three double-quote \"\"\"\"\"\"\",\"four double-quote:\n \"\"\"\"\"\"\"\"\"\n">>, Contents).
+


### PR DESCRIPTION
Hi,
I was referring your code for a simple csv escape function, and found this small bug.
Without the [global] option to binary:replace, only the first double-quote would be replaced.
## Reproduce example

(testnode@127.0.0.1)1> csv_gen:field(standard_io, <<"this is my \"value\".\n">>).
## Expected output:

"this is my ""value""."ok
## Actual output:

"this is my ""value"."ok

Notice the second double-quote is not escaped.
