### PR TITLE
Add support of Unicode

### DIFF
--- a/src/csv_gen.erl
+++ b/src/csv_gen.erl
@@ -19,7 +19,7 @@ field(File, Value) when is_binary(Value) ->
       file:write(File, "\"")
   end;
 field(File, Value) when is_list(Value) ->
-  field(File, list_to_binary(Value));
+  field(File, unicode:characters_to_binary(Value));
 field(File, Value) when is_integer(Value) ->
   file:write(File, integer_to_list(Value));
 field(File, Value) when is_atom(Value) ->

--- a/test/csv_gen_tests.erl
+++ b/test/csv_gen_tests.erl
@@ -5,11 +5,13 @@ write_csv_test() ->
   {ok, File} = file:open("temp.csv", [write]),
   csv_gen:row(File, ["Header 1", "Header 2"]),
   csv_gen:row(File, [1, "hello", <<"good bye">>, "with \" quote","with \n newline", "with , comma", 2.0, "and the atom", hydrogen]),
+  csv_gen:row(File, ["and the unicode", [1084,1072,1084,1072], "that means mother in russian"]),
   file:close(File),
 
   {ok, Contents} = file:read_file("temp.csv"),
   io:format("wrote ~p~n",[Contents]),
-  ?assertEqual(<<"Header 1,Header 2\n1,hello,good bye,\"with \"\" quote\",\"with \n newline\",\"with , comma\",2.000000,and the atom,hydrogen\n">>, Contents).
+  ?assertEqual(<<"Header 1,Header 2\n1,hello,good bye,\"with \"\" quote\",\"with \n newline\",\"with , comma\",2.000000,and the atom,hydrogen\n"
+                 "and the unicode,",208,188,208,176,208,188,208,176,",that means mother in russian\n">>, Contents).
 
 double_quote_test() ->
   {ok, File} = file:open("temp.csv", [write]),


### PR DESCRIPTION
Hi! It crashes on non-latin symbols when doing list_to_binary.
It should be replaces by unicode:characters_to_binary.
Look:
http://erlang.org/doc/apps/stdlib/unicode_usage.html
